### PR TITLE
Fix help message arrow limit

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -269,7 +269,7 @@ void print_status(Game *game) {
 }
 
 void print_help() {
-    printf("\nHint: Enter 'm' followed by a room number to move, or 's' followed by up to 5 room numbers to shoot.\n"
+    printf("\nHint: Enter 'm' followed by a room number to move, or 's' followed by up to 3 room numbers to shoot.\n"
            "Example for move:  m 3 <Enter>\n"
            "Example for shoot: s 1 3 8 <Enter>\n\n");
 }


### PR DESCRIPTION
## Summary
- clarify arrow traversal limit in help text

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683fd0b9baf083339491b0f32782ba70