### PR TITLE
Add SPDX license headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 Nico Schumann <nico.schumann@startmail.com>
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.22.1)
 
 set(CXX_STANDARD 17)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 Nico Schumann <nico.schumann@startmail.com>
+# SPDX-License-Identifier: MIT
+
 wumpus:
 	mkdir build && cd build && cmake .. && make
 
@@ -6,3 +9,4 @@ wumpus:
 
 clean:
 	rm -rf ./build
+

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 Nico Schumann <nico.schumann@startmail.com>
+// SPDX-License-Identifier: MIT
+
 // Hunt the Wumpus! ( https://en.wikipedia.org/Hunt_the_Wumpus )
 // My implementation in C++, according to description at wikipedia article.
 // No external libraries needed. Code is public domain.


### PR DESCRIPTION
## Summary
- add SPDX copyright and license headers to `main.cpp`
- add SPDX headers to build scripts `CMakeLists.txt` and `Makefile`

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68b3929fac348333b3eaaf3718076e31